### PR TITLE
Update rustler configs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nif: ["2.16", "2.15"]
+        nif: ["2.17", "2.16"]
         job:
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
           - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }

--- a/native/rrule/Cargo.toml
+++ b/native/rrule/Cargo.toml
@@ -12,5 +12,10 @@ crate-type = ["cdylib"]
 [dependencies]
 chrono = "0.4.40"
 chrono-tz = "0.10.3"
-rustler = "0.36.1"
+rustler = { version = "0.36", default-features = false, features = ["derive"] }
 rrule = "0.13.0"
+
+[features]
+default = ["nif_version_2_16"]
+nif_version_2_16 = ["rustler/nif_version_2_16"]
+nif_version_2_17 = ["rustler/nif_version_2_17"]

--- a/native/rrule/Cross.toml
+++ b/native/rrule/Cross.toml
@@ -1,4 +1,0 @@
-[build.env]
-passthrough = [
-  "RUSTLER_NIF_VERSION"
-]


### PR DESCRIPTION
`RUSTLER_NIF_VERSION` was deprecated in Rustler 0.30. Replace it with Cargo `features`, as per the config guide:

https://hexdocs.pm/rustler_precompiled/precompilation_guide.html#additional-configuration-before-build

Also:

* Bump `upload-artifact` action to v4
* Drop NIF version 2.15, which targets OTP 22+.
* Add NIF version 2.17, which targets OTP 26+

I hope this fixes the build.